### PR TITLE
FEAT Return board informations

### DIFF
--- a/api/routes/boards.js
+++ b/api/routes/boards.js
@@ -24,6 +24,16 @@ router.get('/:id/lists/', (req, res) => {
   })
 })
 
+router.get('/:id', (req, res) => {
+  Board.findOne({ _id: req.params.id }, (err, board) => {
+    if (err) {
+      res.send(err)
+    } else {
+      res.json(board)
+    }
+  })
+})
+
 router.post('/', (req, res) => {
   const board = new Board({
     title: req.body.title,


### PR DESCRIPTION
The route GET `/boards/:id` return some informations about the board.
Required for displaying board title.